### PR TITLE
added stripping types for flowtype

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ module.exports = function (options) {
             return;
         }
 
-        if (checker._isExcluded(file.path)) {
+        if (checker.getConfiguration().isFileExcluded(file.path)) {
             cb(null, file);
             return;
         }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     ],
     "dependencies": {
         "gulp-util": "^3.0.1",
-        "jscs": "^1.6.2",
+        "jscs": "^1.8.0",
         "react-dom-pragma": "^1.0.0",
         "react-tools": "^0.11.2",
         "through2": "^0.6.2"


### PR DESCRIPTION
Hi,

Thank you very much for this great gulp plugin. It is very useful to me.

Beside React I am just starting to use flowtype checker (http://flowtype.org/)

To be able to make gulp jsxcs work with /\* @flow */ files with type annotations, I added the option {stripTypes: true} to the react.transform.

I don't see any impact on the rest of the features.

Do you think it can be useful to you and/or others ?

Thank you
Best 
Nico
