### PR TITLE
es6 support

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ module.exports = function (options) {
         try {
             checker.configure(loadConfigFile.load(configPath));
         } catch (err) {
-            err.message = 'Unable to load JSCS config file at ' + tildify(path.resolve(configPath)) + '\n' + err.message;
+            err.message = 'Unable to load JSCS config file at ' + configPath + '\n' + err.message;
             throw err;
         }
     } else {


### PR DESCRIPTION
Pass the "esnext" option to "jscs" and "react".
The code mainly comes from https://github.com/jscs-dev/gulp-jscs.